### PR TITLE
Speedy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ xicor is an implementation of the "xi" correlation metric described in Chatterje
 -   Free software: MIT license
 -   Documentation: https://czbiohub.github.io/xicor
 
+
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ xicor is an implementation of the "xi" correlation metric described in Chatterje
 -   Free software: MIT license
 -   Documentation: https://czbiohub.github.io/xicor
 
-
 Installation
 ------------
 

--- a/xicor/xicor.py
+++ b/xicor/xicor.py
@@ -5,7 +5,7 @@ class Xi:
     """
     x and y are the data vectors
     """
-
+    
     def __init__(self, x, y):
 
         self.x = np.array(list(x))
@@ -58,7 +58,7 @@ class Xi:
         # is to be used for calculation P-values:
         # The following steps calculate the theoretical variance
         # in the presence of ties:
-        sorted_ordered_x_rank = sorted(self.y[self.x_ordered])
+        sorted_ordered_x_rank = sorted(self.f[self.x_ordered])
 
         ind = [i + 1 for i in range(self.sample_size)]
         ind2 = [2 * self.sample_size - 2 * ind[i - 1] + 1 for i in ind]

--- a/xicor/xicor.py
+++ b/xicor/xicor.py
@@ -59,7 +59,7 @@ class Xi:
         # is to be used for calculation P-values:
         # The following steps calculate the theoretical variance
         # in the presence of ties:
-        sorted_ordered_x_rank = sorted(self.f)
+        sorted_ordered_x_rank = sorted(self.f/self.sample_size)
 
         ind = [i + 1 for i in range(self.sample_size)]
         ind2 = [2 * self.sample_size - 2 * ind[i - 1] + 1 for i in ind]

--- a/xicor/xicor.py
+++ b/xicor/xicor.py
@@ -2,6 +2,16 @@ import numpy as np
 import scipy.stats as ss
 
 
+def _xicorr(X,Y):
+    n = X.size
+    xi = np.argsort(X,kind='quicksort')
+    Y = Y[xi]
+    _,b,c = np.unique(Y,return_counts=True,return_inverse=True)
+    r = np.cumsum(c)[b]
+    _,b,c = np.unique(-Y,return_counts=True,return_inverse=True)
+    l = np.cumsum(c)[b]
+    return 1 - n*np.abs(np.diff(r)).sum() / (2*(l*(n-l)).sum())
+
 class Xi:
     """
     x and y are the data vectors
@@ -11,74 +21,21 @@ class Xi:
 
         self.x = x
         self.y = y
+        x_tiebroken = self.x.copy()
+        a,ix,c = np.unique(x_tiebroken,return_counts=True,return_inverse=True)
+        f = c[ix] > 1
+        x_tiebroken[f] = x_tiebroken[f] + np.random.rand(f.sum())*1e-6
+        self.x_ordered = np.argsort(x_tiebroken, kind='quicksort')  
+        self.sample_size = len(self.x)
 
-    @property
-    def sample_size(self):
-        return len(self.x)
+        _,b,c = np.unique(self.y[self.x_ordered],return_counts=True,return_inverse=True)
+        self.f = np.cumsum(c)[b]        
+        _,b,c = np.unique(-self.y[self.x_ordered],return_counts=True,return_inverse=True)
+        self.g = np.cumsum(c)[b]  
+        self.numerator = self.sample_size*np.abs(np.diff(self.f)).sum()       
+        self.denominator = 2*(self.g*(self.sample_size-self.g)).sum()
+        self.correlation = 1 - self.numerator / self.denominator
 
-    @property
-    def x_ordered_rank(self):
-        # PI is the rank vector for x, with ties broken at random
-        # Not mine: source (https://stackoverflow.com/a/47430384/1628971)
-        # random shuffling of the data - reason to use random.choice is that
-        # pd.sample(frac=1) uses the same randomizing algorithm
-        len_x = len(self.x)
-        randomized_indices = np.random.choice(np.arange(len_x), len_x, replace=False)
-        randomized = [self.x[idx] for idx in randomized_indices]
-        # same as pandas rank method 'first'
-        rankdata = ss.rankdata(randomized, method="ordinal")
-        # Reindexing based on pairs of indices before and after
-        unrandomized = [
-            rankdata[j] for i, j in sorted(zip(randomized_indices, range(len_x)))
-        ]
-        return unrandomized
-
-    @property
-    def y_rank_max(self):
-        # f[i] is number of j s.t. y[j] <= y[i], divided by n.
-        return ss.rankdata(self.y, method="max") / self.sample_size
-
-    @property
-    def g(self):
-        # g[i] is number of j s.t. y[j] >= y[i], divided by n.
-        return ss.rankdata([-i for i in self.y], method="max") / self.sample_size
-
-    @property
-    def x_ordered(self):
-        # order of the x's, ties broken at random.
-        return np.argsort(self.x_ordered_rank)
-
-    @property
-    def x_rank_max_ordered(self):
-        # Rearrange f according to ord.
-        return [self.y_rank_max[i] for i in self.x_ordered]
-
-    @property
-    def mean_absolute(self):
-        return (
-            np.mean(
-                np.abs(
-                    [
-                        x - y
-                        for x, y in zip(
-                            self.x_rank_max_ordered[0 : (self.sample_size - 1)],
-                            self.x_rank_max_ordered[1 : self.sample_size],
-                        )
-                    ]
-                )
-            )
-            * (self.sample_size - 1)
-            / (2 * self.sample_size)
-        )
-
-    @property
-    def inverse_g_mean(self):
-        return np.mean(self.g * (1 - self.g))
-
-    @property
-    def correlation(self):
-        """xi correlation"""
-        return 1 - self.mean_absolute / self.inverse_g_mean
 
     @classmethod
     def xi(cls, x, y):
@@ -103,7 +60,7 @@ class Xi:
         """
         # If there are no ties, return xi and theoretical P-value:
 
-        if ties:
+        if not ties:
             return 1 - ss.norm.cdf(
                 np.sqrt(self.sample_size) * self.correlation / np.sqrt(2 / 5)
             )
@@ -112,7 +69,7 @@ class Xi:
         # is to be used for calculation P-values:
         # The following steps calculate the theoretical variance
         # in the presence of ties:
-        sorted_ordered_x_rank = sorted(self.x_rank_max_ordered)
+        sorted_ordered_x_rank = sorted(self.y[self.x_ordered])
 
         ind = [i + 1 for i in range(self.sample_size)]
         ind2 = [2 * self.sample_size - 2 * ind[i - 1] + 1 for i in ind]
@@ -135,7 +92,7 @@ class Xi:
         ]
 
         b = np.mean([np.square(i) for i in m])
-        v = (a - 2 * b + np.square(c)) / np.square(self.inverse_g_mean)
+        v = (a - 2 * b + np.square(c)) / np.square(self.denominator)
 
         return 1 - ss.norm.cdf(
             np.sqrt(self.sample_size) * self.correlation / np.sqrt(v)

--- a/xicor/xicor.py
+++ b/xicor/xicor.py
@@ -1,17 +1,6 @@
 import numpy as np
 import scipy.stats as ss
 
-
-def _xicorr(X,Y):
-    n = X.size
-    xi = np.argsort(X,kind='quicksort')
-    Y = Y[xi]
-    _,b,c = np.unique(Y,return_counts=True,return_inverse=True)
-    r = np.cumsum(c)[b]
-    _,b,c = np.unique(-Y,return_counts=True,return_inverse=True)
-    l = np.cumsum(c)[b]
-    return 1 - n*np.abs(np.diff(r)).sum() / (2*(l*(n-l)).sum())
-
 class Xi:
     """
     x and y are the data vectors
@@ -19,8 +8,8 @@ class Xi:
 
     def __init__(self, x, y):
 
-        self.x = x
-        self.y = y
+        self.x = np.array(list(x))
+        self.y = np.array(list(y))
         x_tiebroken = self.x.copy()
         a,ix,c = np.unique(x_tiebroken,return_counts=True,return_inverse=True)
         f = c[ix] > 1

--- a/xicor/xicor.py
+++ b/xicor/xicor.py
@@ -5,7 +5,7 @@ class Xi:
     """
     x and y are the data vectors
     """
-    
+
     def __init__(self, x, y):
 
         self.x = np.array(list(x))
@@ -25,11 +25,12 @@ class Xi:
         self.denominator = 2*(self.g*(self.sample_size-self.g)).sum()
         self.correlation = 1 - self.numerator / self.denominator
 
+        self.inverse_g_mean = np.mean(self.g / self.sample_size * (1 - self.g / self.sample_size))
 
     @classmethod
     def xi(cls, x, y):
         return cls(x, y)
-
+    
     def pval_asymptotic(self, ties=False, nperm=1000):
         """
         Returns p values of the correlation
@@ -58,7 +59,7 @@ class Xi:
         # is to be used for calculation P-values:
         # The following steps calculate the theoretical variance
         # in the presence of ties:
-        sorted_ordered_x_rank = sorted(self.f[self.x_ordered])
+        sorted_ordered_x_rank = sorted(self.f)
 
         ind = [i + 1 for i in range(self.sample_size)]
         ind2 = [2 * self.sample_size - 2 * ind[i - 1] + 1 for i in ind]
@@ -81,7 +82,7 @@ class Xi:
         ]
 
         b = np.mean([np.square(i) for i in m])
-        v = (a - 2 * b + np.square(c)) / np.square(self.denominator)
+        v = (a - 2 * b + np.square(c)) / np.square(self.inverse_g_mean)
 
         return 1 - ss.norm.cdf(
             np.sqrt(self.sample_size) * self.correlation / np.sqrt(v)


### PR DESCRIPTION
Hello! 

I've upgraded the xicor implementation to be much faster. The results are identical compared to the original implementation.

A couple notes:
1) I removed all the properties. Properties are not implicitly cached and so every time you reference a property, it is recalculated. As a result, you are unecessarily re-ranking the data many, many times. 

2) I am using numpy.unique with return_inverse and return_counts flags to quickly calculate `f` and `g`, which means I don't need to explicitly rank any of the data.

3) The `ties` argument in the p-value function was inverted. I fixed the if statement.

Let me know what you think.
